### PR TITLE
Remove unused React imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Login from './pages/Login';
 
 export default function App() {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { AppBar, Toolbar, Typography, Drawer, List, ListItemButton, ListItemIcon, ListItemText, Box } from '@mui/material';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import InputIcon from '@mui/icons-material/Input';
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 
 const drawerWidth = 240;
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
     const navigate = useNavigate();
     return (
         <Box sx={{ display: 'flex' }}>

--- a/src/pages/CajaEntrada.tsx
+++ b/src/pages/CajaEntrada.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Typography } from '@mui/material';
 export default function CajaEntrada() {
     return <Typography variant="h4">Caja Entrada</Typography>;

--- a/src/pages/CajaProceso.tsx
+++ b/src/pages/CajaProceso.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Typography } from '@mui/material';
 export default function CajaProceso() {
     return <Typography variant="h4">Caja Proceso</Typography>;

--- a/src/pages/CajaSalida.tsx
+++ b/src/pages/CajaSalida.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Typography } from '@mui/material';
 export default function CajaSalida() {
     return <Typography variant="h4">Caja Salida</Typography>;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Typography } from '@mui/material';
 export default function Dashboard() {
     return <Typography variant="h1">Dashboard de Groupymes</Typography>;


### PR DESCRIPTION
## Summary
- drop unused `React` default imports
- use `ReactNode` type for `Layout`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a983f94e0832b99edbb5c9d299955