### PR TITLE
Implement login POST and redirect

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,13 +1,25 @@
 import { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 export default function Login() {
     const [user, setUser] = useState('');
     const [pass, setPass] = useState('');
+    const navigate = useNavigate();
 
     const submit = async (e: React.FormEvent) => {
         e.preventDefault();
-        // TODO: llamada a /auth/login
-        console.log({ user, pass });
+        try {
+            const resp = await axios.post('/api/auth/login', {
+                username: user,
+                password: pass,
+            });
+            localStorage.setItem('token', resp.data.access_token);
+            navigate('/');
+        } catch (err) {
+            console.error(err);
+            alert('Error de autenticación');
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary
- implement POST login request via axios
- save token in localStorage and navigate to dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a9d6a13d8832b8198c28ec3b0551f